### PR TITLE
Finishing multi URI. Fixing error with missing params

### DIFF
--- a/app/Events/CommonEvent.php
+++ b/app/Events/CommonEvent.php
@@ -24,7 +24,10 @@ abstract class CommonEvent
      */
     public function __construct(Request $request)
     {
-        $this->setRequest($request);
+        //Fix for missing params in the request
+        //As this project does not use Iluminate\Request directly
+        //Query string is missed for the request
+        $this->setRequest($request->capture());
     }
 
     public function setRequest(Request $request)

--- a/app/Http/Controllers/MultiController.php
+++ b/app/Http/Controllers/MultiController.php
@@ -2,7 +2,6 @@
 
 namespace App\Http\Controllers;
 
-use Illuminate\Http\Request;
 use App\Events\Multi\IndexEvent;
 use App\Http\Requests\Multi\IndexRequest;
 use App\Http\Responses\CommonResponse as Response;

--- a/app/Jobs/Multi/Index.php
+++ b/app/Jobs/Multi/Index.php
@@ -7,12 +7,45 @@ use App\Jobs\CommonJob as Job;
 class Index extends Job
 {
     /**
+     * Create a new job instance.
+     *
+     * @return void
+     */
+    public function __construct($input)
+    {
+    	parent::__construct();
+    	$this->resource = 'search/multi?query='.$input['query'];
+    	$this->method = 'GET';
+    	$this->url =  $this->resource."&api_key=".$this->apiKey;
+    }
+
+    /**
      * Execute the job.
      *
      * @return void
      */
     public function handle()
     {
-        return true;
+        try {
+	        $response = $this->guzzleClient->request(
+	        	$this->method,
+	        	$this->url
+	        );
+
+            return [
+                'status' => $response->getStatusCode(),
+                'content' => json_decode($response->getBody()->getContents())
+            ];
+	    } catch (ClientException $e) {
+            return [
+                'status' => $e->getResponse()->getStatusCode(),
+                'content' => ''
+            ];
+		} catch (Exception $e) {
+            return [
+                'status' => Response::HTTP_INTERNAL_SERVER_ERROR,
+                'content' => ''
+            ];
+		}
     }
 }

--- a/app/Listeners/Multi/HandleIndexEvent.php
+++ b/app/Listeners/Multi/HandleIndexEvent.php
@@ -17,6 +17,8 @@ class HandleIndexEvent extends Listener
     public function handle(IndexEvent $event)
     {
         $input = $event->getRequest()->all();
+        //Get variables from query string
+        $input = array_merge($input, $event->getRequest()->query());
         $results = $this->dispatch(
             new Index($input)
         );


### PR DESCRIPTION
Requests did not have query string because we are using an abstract class to organize requests inheritance